### PR TITLE
Add extra group "Guests"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,6 @@ var
 output.xml
 report.html
 log.html
+/src/collective.workspace.egg-info
+*.pyc
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ Changelog
 1.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Added a new role TeamGuest that can be used to grant reduced access
+  permissions to a workspace
 
 
 1.1 (2014-07-04)

--- a/src/collective/workspace/configure.zcml
+++ b/src/collective/workspace/configure.zcml
@@ -16,6 +16,7 @@
       id="collective.workspace.ViewRoster"
       title="collective.workspace: View roster">
     <role name="TeamMember" />
+    <role name="TeamGuest" />
     <role name="TeamManager" />
     <role name="Site Administrator" />
     <role name="Manager" />

--- a/src/collective/workspace/pas.py
+++ b/src/collective/workspace/pas.py
@@ -108,7 +108,7 @@ class WorkspaceGroupManager(BasePlugin, Cacheable):
             if member_data is not None:
                 member_groups = set(member_data['groups'])
                 # Membership in the Members group is implied, but only for
-                # members who anre not Guests
+                # members who are not Guests
                 if "Guests" not in member_data['groups']:
                     member_groups = member_groups | set([u'Members'])
                 groups.extend([

--- a/src/collective/workspace/pas.py
+++ b/src/collective/workspace/pas.py
@@ -106,8 +106,11 @@ class WorkspaceGroupManager(BasePlugin, Cacheable):
         for workspace in self._iterWorkspaces(user_id):
             member_data = workspace.members.get(user_id)
             if member_data is not None:
-                # Membership in the Members group is implied
-                member_groups = set(member_data['groups']) | set([u'Members'])
+                member_groups = set(member_data['groups'])
+                # Membership in the Members group is implied, but only for
+                # members who anre not Guests
+                if "Guests" not in member_data['groups']:
+                    member_groups = member_groups | set([u'Members'])
                 groups.extend([
                     '%s:%s' % (group_name, workspace.context.UID())
                     for group_name in member_groups

--- a/src/collective/workspace/profiles/default/rolemap.xml
+++ b/src/collective/workspace/profiles/default/rolemap.xml
@@ -2,6 +2,7 @@
 <rolemap>
   <roles>
     <role name="TeamManager"/>
+    <role name="TeamGuest"/>
   </roles>
   <permissions>
   </permissions>

--- a/src/collective/workspace/tests/test_workspace.py
+++ b/src/collective/workspace/tests/test_workspace.py
@@ -3,7 +3,7 @@ import unittest
 from plone import api
 from plone.testing import z2
 from plone.app.testing import SITE_OWNER_NAME
-import transaction
+from zope.annotation.interfaces import IAnnotations
 
 from collective.workspace.testing import \
     COLLECTIVE_WORKSPACE_INTEGRATION_TESTING
@@ -30,11 +30,35 @@ class TestWorkspace(unittest.TestCase):
         )
         self.ws = IWorkspace(self.workspace)
 
+    def reset_annotations(self):
+        annotations = IAnnotations(self.request)
+        keys_to_remove = []
+        for key in annotations.keys():
+            if (
+                isinstance(key, tuple) and
+                key[0].startswith('workspace')
+            ):
+                keys_to_remove.append(key)
+
+        for key in keys_to_remove:
+            annotations.pop(key)
+
     def test_add_to_team(self):
         self.ws.add_to_team(
             user=self.user1.getId()
         )
         self.assertIn(self.user1.getId(), list(self.ws.members))
+
+    def test_local_role_team_member(self):
+        self.ws.add_to_team(
+            user=self.user1.getId()
+        )
+        self.reset_annotations()
+
+        pmt = api.portal.get_tool('portal_membership')
+        member = pmt.getMemberById(self.user1.getId())
+        roles = member.getRolesInContext(self.workspace)
+        self.assertIn('TeamMember', roles)
 
     def test_remove_from_team(self):
         self.ws.add_to_team(
@@ -44,3 +68,20 @@ class TestWorkspace(unittest.TestCase):
             user=self.user1.getId()
         )
         self.assertNotIn(self.user1.getId(), list(self.ws.members))
+
+    def test_add_guest_to_team(self):
+        self.ws.add_to_team(
+            user=self.user1.getId(), groups=['Guests']
+        )
+        self.assertIn(self.user1.getId(), list(self.ws.members))
+
+    def test_guest_has_no_team_member_role(self):
+        self.ws.add_to_team(
+            user=self.user1.getId(), groups=['Guests']
+        )
+        self.reset_annotations()
+        pmt = api.portal.get_tool('portal_membership')
+        member = pmt.getMemberById(self.user1.getId())
+        roles = member.getRolesInContext(self.workspace)
+        self.assertIn('TeamGuest', roles)
+        self.assertNotIn('TeamMember', roles)

--- a/src/collective/workspace/workspace.py
+++ b/src/collective/workspace/workspace.py
@@ -44,6 +44,7 @@ class Workspace(object):
     # Maps group name -> roles
     available_groups = {
         u'Members': ('Contributor', 'Reader', 'TeamMember'),
+        u'Guests': ('TeamGuest', ),
         u'Admins': ('Contributor', 'Editor', 'Reviewer',
                     'Reader', 'TeamManager',),
     }


### PR DESCRIPTION
This provides the groundwork for a new kind of workspace membership: Guest access.

Guest access might be used to grant a user membership to a workspace with a different set of permissions than a regular member. Therefore a new role TeamGuest is introduced. Guests will not get the TeamMember role automatically.