### PR TITLE
Make it possible to have roster entries that are not connected to users

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ Changed functionality:
   Membership attributes should be updated using the `update` method
   to make sure that all changes are properly accounted for.
 - A last modified time is now tracked for each roster membership.
+- It's now possible to add a roster entry that isn't associated with a user
+  (for example, to represent a person who doesn't have a Plone account).
 
 Bugs fixed:
 
@@ -32,6 +34,8 @@ Bugs fixed:
 - New workspace counters can now be added without breaking existing workspaces.
 - Tools are now looked up using `plone.api.portal.get_tool`,
   which helps in some cases where objects are not properly acquisition-wrapped.
+- Make sure UID doesn't get reset when calling add_to_team
+  with a user who is already in the workspace.
 
 Cleanup:
 

--- a/src/collective/workspace/browser.py
+++ b/src/collective/workspace/browser.py
@@ -4,7 +4,6 @@ from collective.workspace.interfaces import _
 from collective.workspace.interfaces import IRosterView
 from collective.workspace.interfaces import IWorkspace
 from collections import namedtuple
-from plone import api
 from plone.autoform.base import AutoFields
 from plone.autoform.form import AutoExtensibleForm
 from plone.z3cform import z2
@@ -86,10 +85,10 @@ class TeamMemberEditForm(AutoExtensibleForm, EditForm):
         self.request = request
         self.workspace = IWorkspace(self.context)
 
-    user_id = None
+    key = None
 
     def publishTraverse(self, request, name):
-        self.user_id = name
+        self.key = name
         return self
 
     @lazy_property
@@ -99,31 +98,26 @@ class TeamMemberEditForm(AutoExtensibleForm, EditForm):
     def updateFields(self):
         super(TeamMemberEditForm, self).updateFields()
         # don't show the user field if we are editing
-        if self.user_id:
+        if self.key:
             del self.fields['user']
 
     @lazy_property
     def ignoreContext(self):
-        return not bool(self.user_id)
+        return not bool(self.key)
 
     @lazy_property
     def label(self):
-        if self.user_id:
-            mtool = api.portal.get_tool('portal_membership')
-            member = mtool.getMemberById(self.user_id)
-            if member is not None:
-                return member.getProperty('fullname') or self.user_id
-            else:
-                return self.user_id
+        if self.key:
+            return self.getContent()._title
         else:
             return _(u'Add Person to Roster')
 
     @lazy_property
     def _content(self):
-        if not self.user_id:
+        if not self.key:
             return self.context
         workspace = self.workspace
-        memberdata = workspace.members[self.user_id]
+        memberdata = workspace.members[self.key]
         return workspace.membership_factory(workspace, memberdata)
 
     def getContent(self):
@@ -136,11 +130,12 @@ class TeamMemberEditForm(AutoExtensibleForm, EditForm):
     def handleSave(self, action):
         data, errors = self.extractData()
         if errors:
+            self.status = self.formErrorsMessage
             return
 
         status = _(u'Changes saved')
 
-        if self.user_id:
+        if self.key:
             membership = self.getContent()
             membership.update(data)
         else:
@@ -160,7 +155,7 @@ class TeamMemberEditForm(AutoExtensibleForm, EditForm):
 
     @property
     def can_remove(self):
-        return self.user_id
+        return self.key
 
     @button.buttonAndHandler(
         _(u'Remove'), condition=lambda self: self.can_remove)


### PR DESCRIPTION
This can be used for example to include people in the roster who don't have Plone accounts. The main change is to loosen the assumption that a roster entry's key is always its user's user id. If no user id is specified for a roster entry, it will be stored using a randomly generated uuid as a key.