### PR TITLE
Fixes an edge case where the migration was failing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 2.0 (unreleased)
 ----------------
 
-- Nothing changed yet.
+Bugs fixed:
+
+- an edge case where the migration was failing (Fixes #25)
 
 
 2.0b1 (2018-03-16)

--- a/src/collective/workspace/membership.py
+++ b/src/collective/workspace/membership.py
@@ -1,13 +1,13 @@
 from BTrees.Length import Length
-from DateTime import DateTime
 from collective.workspace.events import TeamMemberModifiedEvent
 from collective.workspace.events import TeamMemberRemovedEvent
 from collective.workspace.interfaces import _
 from collective.workspace.interfaces import IWorkspace
-from collective.workspace.pas import get_workspace_groups_plugin
 from collective.workspace.pas import add_group
+from collective.workspace.pas import get_workspace_groups_plugin
 from collective.workspace.vocabs import UsersSource
 from copy import deepcopy
+from DateTime import DateTime
 from plone import api
 from plone.autoform import directives as form
 from plone.formwidget.autocomplete import AutocompleteFieldWidget
@@ -125,7 +125,7 @@ class TeamMembership(object):
     @property
     def groups(self):
         # Don't include automatic groups
-        groups = self.__dict__.get('groups', set()).copy()
+        groups = set(self.__dict__.get('groups') or set())
         groups -= set(self.workspace.auto_groups.keys())
         return groups
 


### PR DESCRIPTION
Fixes #25 

This should not break the property if the value for the 'group' key is a list, a tuple or None