### PR TITLE
Fixes for the _update_groups method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,9 +6,9 @@ Changelog
 
 Bugs fixed:
 
-- fixes the groups authomatic groups calculation in some cases.
-  The bug was preventing the users to be added to the ``Members``
-  in some cases, e.g. during the upgrade step from version 1.x
+- Fixes the automatic groups calculation in some cases.
+  The bug was preventing the users from being added to the ``Members``
+  group in some cases, e.g. during the upgrade step from version 1.x
   (Fixes #27)
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,12 @@ Changelog
 2.0 (unreleased)
 ----------------
 
-- Nothing changed yet.
+Bugs fixed:
+
+- fixes the groups authomatic groups calculation in some cases.
+  The bug was preventing the users to be added to the ``Members``
+  in some cases, e.g. during the upgrade step from version 1.x
+  (Fixes #27)
 
 
 2.0b2 (2018-04-10)

--- a/src/collective/workspace/membership.py
+++ b/src/collective/workspace/membership.py
@@ -100,9 +100,6 @@ class TeamMembership(object):
             for name, condition in workspace.auto_groups.items():
                 if name not in workspace.available_groups:
                     raise Exception('Unknown workspace group: {}'.format(name))
-                if name in new_groups or name in old_groups:
-                    # Respect user input
-                    pass
                 # only add the automatic groups if condition is satisfied,
                 # otherwise remove it
                 if condition(self):

--- a/src/collective/workspace/membership.py
+++ b/src/collective/workspace/membership.py
@@ -85,7 +85,7 @@ class TeamMembership(object):
             )
         super(TeamMembership, self).__setattr__(name, value)
 
-    def _update_groups(self, old_groups, new_groups, add_auto_groups=True):
+    def _update_groups(self, old_groups, new_groups):
         workspace = self.workspace
         context = workspace.context
         uid = context.UID()
@@ -93,19 +93,25 @@ class TeamMembership(object):
         if self.user is None:
             return
 
+        for group_name in new_groups:
+            if group_name not in workspace.available_groups:
+                raise ValueError(
+                    'Unknown workspace group: {}'.format(group_name))
+        if self.groups != new_groups:
+            self.__dict__['groups'] = new_groups.copy()
+
         # Determine automatic groups
-        if add_auto_groups:
-            new_groups = set(new_groups)
-            old_groups = set(old_groups)
-            for name, condition in workspace.auto_groups.items():
-                if name not in workspace.available_groups:
-                    raise Exception('Unknown workspace group: {}'.format(name))
-                # only add the automatic groups if condition is satisfied,
-                # otherwise remove it
-                if condition(self):
-                    new_groups.add(name)
-                else:
-                    old_groups.add(name)
+        new_groups = set(new_groups)
+        old_groups = set(old_groups)
+        for name, condition in workspace.auto_groups.items():
+            if name not in workspace.available_groups:
+                raise Exception('Unknown workspace group: {}'.format(name))
+            # only add the automatic groups if condition is satisfied,
+            # otherwise remove it
+            if condition(self):
+                new_groups.add(name)
+            else:
+                old_groups.add(name)
 
         # Add to new groups
         for group_name in (new_groups - old_groups):
@@ -126,6 +132,18 @@ class TeamMembership(object):
             except KeyError:  # group doesn't exist
                 pass
 
+    def _remove_all_groups(self):
+        workspace = self.workspace
+        uid = workspace.context.UID()
+        workspace_groups = get_workspace_groups_plugin()
+        groups = set(self.groups) | set(workspace.available_groups)
+        for group_name in groups:
+            group_id = '{}:{}'.format(group_name.encode('utf8'), uid)
+            try:
+                workspace_groups.removePrincipalFromGroup(self.user, group_id)
+            except KeyError:  # group doesn't exist
+                pass
+
     @property
     def groups(self):
         # Don't include automatic groups
@@ -140,7 +158,7 @@ class TeamMembership(object):
         if 'user' in data and old['user'] != data['user']:
             # User is changing, so remove the old user from groups.
             user_changed = True
-            self._update_groups(old['groups'], set())
+            self._remove_all_groups()
         data['_mtime'] = DateTime()
         self.__dict__.update(data)
         # make sure change is persisted
@@ -191,11 +209,7 @@ class TeamMembership(object):
             if func(self.__dict__):
                 workspace.context._counters[name].change(-1)
         del self.workspace.members[self._key]
-        self._update_groups(
-            self.groups | set(self.workspace.auto_groups),
-            set(),
-            add_auto_groups=False
-        )
+        self._remove_all_groups()
         self.handle_removed()
         notify(TeamMemberRemovedEvent(self.workspace.context, self))
         self.workspace.context.reindexObject(idxs=['workspace_members'])

--- a/src/collective/workspace/membership.py
+++ b/src/collective/workspace/membership.py
@@ -105,7 +105,7 @@ class TeamMembership(object):
                     pass
                 # only add the automatic groups if condition is satisfied,
                 # otherwise remove it
-                if condition(self, new_groups):
+                if condition(self):
                     new_groups.add(name)
                 else:
                     old_groups.add(name)

--- a/src/collective/workspace/setuphandlers.py
+++ b/src/collective/workspace/setuphandlers.py
@@ -43,8 +43,5 @@ def migrate_groups(context):
             title = '{}: {}'.format(group_name.encode('utf8'), b.Title)
             add_group(group_id, title)
         for m in workspace:
-            new_groups = (
-                (m.groups | set([u'Members'])) &
-                set(workspace.available_groups)
-            )
-            m._update_groups(set(), new_groups, add_auto_groups=False)
+            new_groups = m.groups & set(workspace.available_groups)
+            m._update_groups(set(), new_groups)

--- a/src/collective/workspace/tests/test_workspace.py
+++ b/src/collective/workspace/tests/test_workspace.py
@@ -28,7 +28,7 @@ class TestWorkspace(unittest.TestCase):
         )
         self.ws = IWorkspace(self.workspace)
 
-    def _check_roles_in_workspace(self):
+    def _get_roles_in_workspace(self):
         pmt = api.portal.get_tool('portal_membership')
         member = pmt.getMemberById(self.user1.getId())
         return member.getRolesInContext(self.workspace)
@@ -109,7 +109,7 @@ class TestWorkspace(unittest.TestCase):
         self.ws.add_to_team(
             user=self.user1.getId()
         )
-        self.assertIn('TeamMember', self._check_roles_in_workspace())
+        self.assertIn('TeamMember', self._get_roles_in_workspace())
 
     def test_remove_from_team(self):
         self.ws.add_to_team(
@@ -215,77 +215,77 @@ class TestWorkspace(unittest.TestCase):
         add_auto_groups parameter set to True (the default) will always add
         the Members group, unless the user is also in the Guests group
         '''
-        self.assertNotIn('TeamMember', self._check_roles_in_workspace())
+        self.assertNotIn('TeamMember', self._get_roles_in_workspace())
 
         # Adding the user to the workspace will grant the TeamMember role
         membership = self.ws.add_to_team(user=self.user1.getId())
-        self.assertIn('TeamMember', self._check_roles_in_workspace())
+        self.assertIn('TeamMember', self._get_roles_in_workspace())
 
         # groups should be untouched
         old = set()
         new = set()
         membership._update_groups(old, new)
-        self.assertIn('TeamMember', self._check_roles_in_workspace())
+        self.assertIn('TeamMember', self._get_roles_in_workspace())
 
         # groups should be untouched because user is already a member
         old = set()
         new = set(['Members'])
         membership._update_groups(old, new)
-        self.assertIn('TeamMember', self._check_roles_in_workspace())
+        self.assertIn('TeamMember', self._get_roles_in_workspace())
 
         # Removing the automatic group will not actually remove it
         # because it is an automatic group
         old = set(['Members'])
         new = set()
         membership._update_groups(old, new)
-        self.assertIn('TeamMember', self._check_roles_in_workspace())
+        self.assertIn('TeamMember', self._get_roles_in_workspace())
 
         # Removing the automatic group will have no effect
         old = set(['Members'])
         new = set()
         membership._update_groups(old, new)
-        self.assertIn('TeamMember', self._check_roles_in_workspace())
+        self.assertIn('TeamMember', self._get_roles_in_workspace())
 
         # Adding the user to the Guests group will remove it from the Members
         # because the condition will not be satisifed
         old = set()
         new = set(['Guests'])
         membership._update_groups(old, new)
-        self.assertIn('TeamGuest', self._check_roles_in_workspace())
-        self.assertNotIn('TeamMember', self._check_roles_in_workspace())
+        self.assertIn('TeamGuest', self._get_roles_in_workspace())
+        self.assertNotIn('TeamMember', self._get_roles_in_workspace())
 
     def test_update_membership_add_auto_groups_False(self):
         ''' Test that calling _update_groups with the
         add_auto_groups parameter set to False, respects the user input
         '''
-        self.assertNotIn('TeamMember', self._check_roles_in_workspace())
+        self.assertNotIn('TeamMember', self._get_roles_in_workspace())
 
         # Adding the user to the workspace will grant the TeamMember role
         membership = self.ws.add_to_team(user=self.user1.getId())
-        self.assertIn('TeamMember', self._check_roles_in_workspace())
+        self.assertIn('TeamMember', self._get_roles_in_workspace())
 
         # groups should be untouched
         old = set()
         new = set()
         membership._update_groups(old, new, add_auto_groups=False)
-        self.assertIn('TeamMember', self._check_roles_in_workspace())
+        self.assertIn('TeamMember', self._get_roles_in_workspace())
 
         # groups should be untouched because user is already a member
         old = set()
         new = set(['Members'])
         membership._update_groups(old, new, add_auto_groups=False)
-        self.assertIn('TeamMember', self._check_roles_in_workspace())
+        self.assertIn('TeamMember', self._get_roles_in_workspace())
 
         # Adding the user to the Guest group will not remove it from Members
         # because add_auto_groups is False
         old = set()
         new = set(['Guests'])
         membership._update_groups(old, new, add_auto_groups=False)
-        self.assertIn('TeamGuest', self._check_roles_in_workspace())
-        self.assertIn('TeamMember', self._check_roles_in_workspace())
+        self.assertIn('TeamGuest', self._get_roles_in_workspace())
+        self.assertIn('TeamMember', self._get_roles_in_workspace())
 
         # Removing the automatic group will actually remove it
         old = set(['Members'])
         new = set()
         membership._update_groups(old, new, add_auto_groups=False)
-        self.assertNotIn('TeamMember', self._check_roles_in_workspace())
+        self.assertNotIn('TeamMember', self._get_roles_in_workspace())

--- a/src/collective/workspace/tests/test_workspace.py
+++ b/src/collective/workspace/tests/test_workspace.py
@@ -210,9 +210,8 @@ class TestWorkspace(unittest.TestCase):
         api.group.delete(test_group_id)
         self.assertIsNone(api.group.get(test_group_id))
 
-    def test_update_membership_add_auto_groups_True(self):
-        ''' Test that calling _update_groups with the
-        add_auto_groups parameter set to True (the default) will always add
+    def test_update_membership_groups(self):
+        ''' Test that calling _update_groups will always add
         the Members group, unless the user is also in the Guests group
         '''
         self.assertNotIn('TeamMember', self._get_roles_in_workspace())
@@ -252,13 +251,10 @@ class TestWorkspace(unittest.TestCase):
         new = set(['Guests'])
         membership._update_groups(old, new)
         self.assertIn('TeamGuest', self._get_roles_in_workspace())
-        # This actually fails beacuse the condition checks only
-        # the existing groups and not the ones passed in the argument
-        # self.assertNotIn('TeamMember', self._get_roles_in_workspace())
+        self.assertNotIn('TeamMember', self._get_roles_in_workspace())
 
-    def test_update_membership_add_auto_groups_False(self):
-        ''' Test that calling _update_groups with the
-        add_auto_groups parameter set to False, respects the user input
+    def test_membership_remove_all_groups(self):
+        ''' Test that calling _remove_all_groups does so
         '''
         self.assertNotIn('TeamMember', self._get_roles_in_workspace())
 
@@ -266,28 +262,6 @@ class TestWorkspace(unittest.TestCase):
         membership = self.ws.add_to_team(user=self.user1.getId())
         self.assertIn('TeamMember', self._get_roles_in_workspace())
 
-        # groups should be untouched
-        old = set()
-        new = set()
-        membership._update_groups(old, new, add_auto_groups=False)
-        self.assertIn('TeamMember', self._get_roles_in_workspace())
-
-        # groups should be untouched because user is already a member
-        old = set()
-        new = set(['Members'])
-        membership._update_groups(old, new, add_auto_groups=False)
-        self.assertIn('TeamMember', self._get_roles_in_workspace())
-
-        # Adding the user to the Guest group will not remove it from Members
-        # because add_auto_groups is False
-        old = set()
-        new = set(['Guests'])
-        membership._update_groups(old, new, add_auto_groups=False)
-        self.assertIn('TeamGuest', self._get_roles_in_workspace())
-        self.assertIn('TeamMember', self._get_roles_in_workspace())
-
-        # Removing the automatic group will actually remove it
-        old = set(['Members'])
-        new = set()
-        membership._update_groups(old, new, add_auto_groups=False)
+        # groups should be removed
+        membership._remove_all_groups()
         self.assertNotIn('TeamMember', self._get_roles_in_workspace())

--- a/src/collective/workspace/tests/test_workspace.py
+++ b/src/collective/workspace/tests/test_workspace.py
@@ -252,7 +252,9 @@ class TestWorkspace(unittest.TestCase):
         new = set(['Guests'])
         membership._update_groups(old, new)
         self.assertIn('TeamGuest', self._get_roles_in_workspace())
-        self.assertNotIn('TeamMember', self._get_roles_in_workspace())
+        # This actually fails beacuse the condition checks only
+        # the existing groups and not the ones passed in the argument
+        # self.assertNotIn('TeamMember', self._get_roles_in_workspace())
 
     def test_update_membership_add_auto_groups_False(self):
         ''' Test that calling _update_groups with the

--- a/src/collective/workspace/workspace.py
+++ b/src/collective/workspace/workspace.py
@@ -1,24 +1,23 @@
-from BTrees.Length import Length
-from BTrees.OOBTree import OOBTree
-from DateTime import DateTime
-from plone.uuid.interfaces import IUUIDGenerator
-from Products.PluggableAuthService.interfaces.events import \
-    IPrincipalDeletedEvent
 from .events import TeamMemberAddedEvent
 from .interfaces import IHasWorkspace
 from .interfaces import IWorkspace
 from .membership import ITeamMembership
 from .membership import TeamMembership
-from .pas import get_workspace_groups_plugin
 from .pas import add_group
+from .pas import get_workspace_groups_plugin
+from BTrees.Length import Length
+from BTrees.OOBTree import OOBTree
+from DateTime import DateTime
 from plone import api
+from plone.uuid.interfaces import IUUIDGenerator
+from Products.PluggableAuthService.interfaces.events import IPrincipalDeletedEvent  # noqa: E501
 from zope.component import adapter
 from zope.component import getUtility
 from zope.container.interfaces import IObjectAddedEvent
 from zope.container.interfaces import IObjectRemovedEvent
-from zope.lifecycleevent.interfaces import IObjectModifiedEvent
-from zope.lifecycleevent.interfaces import IObjectCopiedEvent
 from zope.event import notify
+from zope.lifecycleevent.interfaces import IObjectCopiedEvent
+from zope.lifecycleevent.interfaces import IObjectModifiedEvent
 
 
 class Workspace(object):
@@ -66,7 +65,7 @@ class Workspace(object):
 
     # Add everyone on the roster to the Members group
     auto_groups = {
-        u'Members': lambda x: 'Guests' not in x.groups,
+        u'Members': lambda x, new_groups=set(): 'Guests' not in set(x.groups) | new_groups,  # noqa: E501
     }
 
     counters = (

--- a/src/collective/workspace/workspace.py
+++ b/src/collective/workspace/workspace.py
@@ -65,7 +65,7 @@ class Workspace(object):
 
     # Add everyone on the roster to the Members group
     auto_groups = {
-        u'Members': lambda x, new_groups=set(): 'Guests' not in set(x.groups) | new_groups,  # noqa: E501
+        u'Members': lambda x: 'Guests' not in set(x.groups),
     }
 
     counters = (


### PR DESCRIPTION
This PR adds some test coverage for the `_update_groups method` and fixes its behavior.
For example, it was possible to have a user both in the Members and in the Guests groups, given that the condition was only checking on the existent groups.
Also it does not remove the Members group when calling this method with `add_auto_groups=False`.

Closes #27 