### PR TITLE
Fix the build

### DIFF
--- a/plone-5.2.x.cfg
+++ b/plone-5.2.x.cfg
@@ -4,3 +4,7 @@ extends =
     https://dist.plone.org/release/5.2.1/versions.cfg
 find-links += https://dist.plone.org/thirdparty/
 versions=versions
+
+[versions]
+# fixes Error: The requirement ('importlib-metadata>=1') is not allowed by your [versions] constraint (0.20)
+importlib-metadata = 1.7.0

--- a/plone-5.2.x.cfg
+++ b/plone-5.2.x.cfg
@@ -8,3 +8,7 @@ versions=versions
 [versions]
 # fixes Error: The requirement ('importlib-metadata>=1') is not allowed by your [versions] constraint (0.20)
 importlib-metadata = 1.7.0
+
+[versions:python27]
+# fixes Error: The requirement ('importlib-metadata>=1') is not allowed by your [versions] constraint (0.20)
+importlib-metadata = 1.6.1


### PR DESCRIPTION
Pinned a newer version of importlib-metadata. Fixes "Error: The requirement ('importlib-metadata>=1') is not allowed by your [versions] constraint (0.20)"

Please note, I don't know whether this might have any unwanted side effects, but it does fix the build for me. Another approach might be to pin twine to a lower version.

See also #44 