### PR TITLE
[3.x] Fix GHA on Plone 5.2

### DIFF
--- a/.gha.cfg
+++ b/.gha.cfg
@@ -5,3 +5,8 @@ extends = plone-x.x.x.cfg
 recipe = plone.recipe.codeanalysis
 pre-commit-hook = False
 return-status-codes = True
+
+[versions]
+# Use the versions from the requirements files
+setuptools =
+zc.buildout =

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,19 +15,15 @@ jobs:
     strategy:
       matrix:
         config:
-          - ["Py2.7-Plone5.1", "2.7", "5.1"]
-          - ["Py2.7-Plone5.2", "2.7", "5.2"]
-          - ["Py3.6-Plone5.2", "3.6", "5.2"]
-          - ["Py3.7-Plone5.2", "3.7", "5.2"]
           - ["Py3.8-Plone5.2", "3.8", "5.2"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.config[1] }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.config[1] }}
       - name: Pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/pip
@@ -44,10 +40,14 @@ jobs:
           echo "[buildout]" > $HOME/.buildout/default.cfg
           echo "download-cache = $HOME/buildout-cache/downloads" >> $HOME/.buildout/default.cfg
           echo "eggs-directory = $HOME/buildout-cache/eggs" >> $HOME/.buildout/default.cfg
-          wget https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz
-          mkdir geckodriver && tar zxvf geckodriver-v0.26.0-linux64.tar.gz -C geckodriver
-          python -m pip install --upgrade pip
+          echo "abi-tag-eggs = true" >> $HOME/.buildout/default.cfg
+
+      - name: Install requirements and buildout
+        run: |
           pip install -r requirements.txt
+
+      - name: Run buildout
+        run: |
           sed -ie "s#plone-x.x.x.cfg#plone-${{ matrix.config[2] }}.x.cfg#" .gha.cfg
           buildout -c .gha.cfg
       - name: Test

--- a/plone-5.2.x.cfg
+++ b/plone-5.2.x.cfg
@@ -1,7 +1,7 @@
 [buildout]
 extends =
     base.cfg
-    https://dist.plone.org/release/5.2.3/versions.cfg
+    https://dist.plone.org/release/5.2.15/versions.cfg
 find-links += https://dist.plone.org/thirdparty/
 versions=versions
 show-picked-versions = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-# Keep this file in sync with: https://github.com/kitconcept/buildout/edit/master/requirements.txt
-setuptools==42.0.2
-zc.buildout==2.13.3
-wheel
+setuptools==75.3.0
+wheel==0.45.1
+zc.buildout==3.4


### PR DESCRIPTION
This removes the tests for Plone/Python versions that are obsolete and for which running the tests on GHA would require too much magic.